### PR TITLE
use friendlier colors; smaller logo

### DIFF
--- a/gurobi_sphinxtheme/__init__.py
+++ b/gurobi_sphinxtheme/__init__.py
@@ -102,11 +102,15 @@ def update_config(app):
     app.builder.theme_options.update({
         "light_css_variables": {
             "color-brand-primary": "#DD2113",
-            "color-brand-content": "#1675a9",
+            "color-brand-content": "#1675A9",
+            "color-topic-title": "#1675A9",
+            "color-topic-title-background": "#1675A933",
+            "color-admonition-title--important": "#1675A9",
+            "color-admonition-title-background--important": "#1675A933",
         },
         "dark_css_variables": {
-            "color-brand-primary": "#DD2113",
-            "color-brand-content": "#1675a9",
+            "color-brand-primary": "#DC4747",
+            "color-brand-content": "#5A9BD5",
         },
         "sidebar_hide_name": True,
         "light_logo": "gurobi_light.svg",

--- a/gurobi_sphinxtheme/theme/static/gurobi.css
+++ b/gurobi_sphinxtheme/theme/static/gurobi.css
@@ -22,3 +22,7 @@ h4 {
 .search__outer__input {
   color: black;
 }
+
+.sidebar-logo {
+  max-width: 80%;
+}


### PR DESCRIPTION
- change the info and important blocks to a blue shade (was green before)
- use slightly more friendly colors in dark mode
- decrease logo to about the same size of our main webpage