### PR TITLE
add status page banner to all pages

### DIFF
--- a/gurobi_sphinxtheme/theme/pagebase.html
+++ b/gurobi_sphinxtheme/theme/pagebase.html
@@ -88,7 +88,9 @@
           </label>
         </div>
         <article role="main">
-          {% block content %}{{ body }}{% endblock %}
+          {% block content %}{{ body }}
+          <script src="https://status.gurobi.com/embed/script.js"></script>
+          {% endblock %}
         </article>
       </div>
       <footer>


### PR DESCRIPTION
This adds our status page banner to the docs.

<img width="1131" alt="image" src="https://github.com/Gurobi/gurobi-sphinxtheme/assets/1506995/f3663064-14e5-418c-b609-0cedd6ababa2">
