### PR TITLE
relative header sizes and ensure h5 is not too small

### DIFF
--- a/gurobi_sphinxtheme/theme/static/gurobi.css
+++ b/gurobi_sphinxtheme/theme/static/gurobi.css
@@ -1,22 +1,30 @@
+body {
+  font-size: 16px; /* Base font size */
+}
+
 h1 {
-  font-size: 30px;
+  font-size: 2em; /* 32px */
 }
 
 h2 {
-  font-size: 24px;
+  font-size: 1.5em; /* 24px */
+}
+
+h3 {
+  font-size: 1.25em; /* 20px */
+}
+
+h4 {
+  font-size: 1.17em; /* 18.72px */
+}
+
+h5 {
+  font-size: 1em; /* 16px */
 }
 
 h2::before {
   content: "\203A\0020";
   color: var(--color-brand-primary);
-}
-
-h3 {
-  font-size: 20px;
-}
-
-h4 {
-  font-size: 16px;
 }
 
 .epilog table {


### PR DESCRIPTION
This fixes https://github.com/Gurobi/docs-optimizer/issues/305.