### PR TITLE
Add a placeholder before the version flyout loads

### DIFF
--- a/docs_gurobi_com/theme/pagebase.html
+++ b/docs_gurobi_com/theme/pagebase.html
@@ -7,7 +7,6 @@
 {% endif %}
 {% if gurobi_rtd %}
 <script src="{{ pathto('_static/versionflyout.js', 1) }}"></script>
-<link href="{{ pathto('_static/versionflyout.css', 1) }}" rel="stylesheet" type="text/css"/>
 <meta content="1" name="readthedocs-addons-api-version"/>
 {% endif %}
 {% endblock %}

--- a/docs_gurobi_com/theme/static/versionflyout.css
+++ b/docs_gurobi_com/theme/static/versionflyout.css
@@ -1,8 +1,8 @@
-.rst-current-version {
+.grb-rtd-current-version {
     cursor: pointer;
 }
 
-.rst-other-versions {
+.grb-rtd-other-versions {
     display: none;
 }
 
@@ -53,29 +53,25 @@ ul.fas li .fa-large:before {
     vertical-align: baseline
 }
 
-div.rst-versions {
+div.grb-rtd-versions {
     border-top: 1px solid var(--color-sidebar-search-border);
     border-left: 1px solid var(--color-sidebar-search-border);
 
 }
 
-.rst-versions {
+.grb-rtd-versions {
     color: var(--color-foreground-primary);
     background: var(--color-background-secondary);
     font-family: Lato, proxima-nova, Helvetica Neue, Arial, sans-serif;
     z-index: 400
 }
 
-.rst-versions a {
+.grb-rtd-versions a {
     color: #2980b9;
     text-decoration: none
 }
 
-.rst-versions .rst-badge-small {
-    display: none
-}
-
-.rst-versions .rst-current-version {
+.grb-rtd-versions .grb-rtd-current-version {
     padding: 12px;
     background-color: var(--color-background-secondary);
     display: block;
@@ -85,40 +81,40 @@ div.rst-versions {
     color: var(--color-brand-primary)
 }
 
-.rst-versions .rst-current-version:after {
+.grb-rtd-versions .grb-rtd-current-version:after {
     clear: both;
     content: "";
     display: block
 }
 
-.rst-versions .rst-current-version .fa {
+.grb-rtd-versions .grb-rtd-current-version .fa {
     color: var(--color-foreground-primary);
     background-color: var(--color-background-secondary)
 }
 
-.rst-versions .rst-current-version .fa-book,
-.rst-versions .rst-current-version .icon-book {
+.grb-rtd-versions .grb-rtd-current-version .fa-book,
+.grb-rtd-versions .grb-rtd-current-version .icon-book {
     float: left
 }
 
-.rst-versions.shift-up {
+.grb-rtd-versions.shift-up {
     height: auto;
     max-height: 100%;
     overflow-y: scroll
 }
 
-.rst-versions.shift-up .rst-other-versions {
+.grb-rtd-versions.shift-up .grb-rtd-other-versions {
     display: block
 }
 
-.rst-versions .rst-other-versions {
+.grb-rtd-versions .grb-rtd-other-versions {
     font-size: 90%;
     padding: 12px;
     color: grey;
     display: none
 }
 
-.rst-versions .rst-other-versions hr {
+.grb-rtd-versions .grb-rtd-other-versions hr {
     display: block;
     height: 1px;
     border: 0;
@@ -127,51 +123,17 @@ div.rst-versions {
     border-top: 1px solid #413d3d
 }
 
-.rst-versions .rst-other-versions dd {
+.grb-rtd-versions .grb-rtd-other-versions dd {
     display: inline-block;
     margin: 0
 }
 
-.rst-versions .rst-other-versions dd a {
+.grb-rtd-versions .grb-rtd-other-versions dd a {
     display: inline-block;
     padding: 6px;
     color: var(--color-foreground-primary)
 }
 
-.rst-versions .rst-other-versions .rtd-current-item {
+.grb-rtd-versions .grb-rtd-other-versions .rtd-current-item {
     font-weight: 700
-}
-
-.rst-versions.rst-badge {
-    width: auto;
-    bottom: 20px;
-    right: 20px;
-    left: auto;
-    border: none;
-    max-width: 300px;
-    max-height: 90%
-}
-
-.rst-versions.rst-badge .fa-book,
-.rst-versions.rst-badge .icon-book {
-    float: none;
-    line-height: 30px
-}
-
-.rst-versions.rst-badge.shift-up .rst-current-version {
-    text-align: right
-}
-
-.rst-versions.rst-badge.shift-up .rst-current-version .fa-book,
-.rst-versions.rst-badge.shift-up .rst-current-version .icon-book {
-    float: left
-}
-
-.rst-versions.rst-badge>.rst-current-version {
-    width: auto;
-    height: 30px;
-    line-height: 30px;
-    padding: 0 6px;
-    display: block;
-    text-align: center
 }

--- a/docs_gurobi_com/theme/static/versionflyout.js
+++ b/docs_gurobi_com/theme/static/versionflyout.js
@@ -155,10 +155,10 @@ document.addEventListener("readthedocs-addons-data-ready", function (event) {
   `;
 
   // Inject the generated content into the placeholders created in versionflyout.html
-  document.getElementById("custom-rtd-flyout-content").innerHTML = flyout;
-  document.getElementById("rtd-version-label").innerHTML = thisVersionLabel;
+  document.getElementById("grb-rtd-flyout-content").innerHTML = flyout;
+  document.getElementById("grb-rtd-version-label").innerHTML = thisVersionLabel;
 
-  document.querySelector(".rst-current-version").addEventListener("click", function() {
+  document.querySelector(".grb-rtd-current-version").addEventListener("click", function() {
     this.classList.toggle("active");
     var content = this.nextElementSibling;
     if (content.style.display === "block") {

--- a/docs_gurobi_com/theme/static/versionflyout.js
+++ b/docs_gurobi_com/theme/static/versionflyout.js
@@ -128,42 +128,35 @@ document.addEventListener("readthedocs-addons-data-ready", function (event) {
   const versionsArray = getVersionsArray(config);
 
   const flyout = `
-    <div class="rst-versions" data-toggle="rst-versions" role="note">
-      <span class="rst-current-version" data-toggle="rst-current-version">
-        <span class="fa fa-book">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -100 1664 1664" width="13" height="13" style="transform: scaleY(-1) translateY(-1px);">
-            <path fill="var(--color-foreground-primary)" d="M1639 1058q40 -57 18 -129l-275 -906q-19 -64 -76.5 -107.5t-122.5 -43.5h-923q-77 0 -148.5 53.5t-99.5 131.5q-24 67 -2 127q0 4 3 27t4 37q1 8 -3 21.5t-3 19.5q2 11 8 21t16.5 23.5t16.5 23.5q23 38 45 91.5t30 91.5q3 10 0.5 30t-0.5 28q3 11 17 28t17 23q21 36 42 92t25 90q1 9 -2.5 32t0.5 28q4 13 22 30.5t22 22.5q19 26 42.5 84.5t27.5 96.5q1 8 -3 25.5t-2 26.5q2 8 9 18t18 23t17 21q8 12 16.5 30.5t15 35t16 36t19.5 32t26.5 23.5t36 11.5t47.5 -5.5l-1 -3q38 9 51 9h761q74 0 114 -56t18 -130l-274 -906q-36 -119 -71.5 -153.5t-128.5 -34.5h-869q-27 0 -38 -15q-11 -16 -1 -43q24 -70 144 -70h923q29 0 56 15.5t35 41.5l300 987q7 22 5 57q38 -15 59 -43zM575 1056q-4 -13 2 -22.5t20 -9.5h608q13 0 25.5 9.5t16.5 22.5l21 64q4 13 -2 22.5t-20 9.5h-608q-13 0 -25.5 -9.5t-16.5 -22.5zM492 800q-4 -13 2 -22.5t20 -9.5h608q13 0 25.5 9.5t16.5 22.5l21 64q4 13 -2 22.5t-20 9.5h-608q-13 0 -25.5 -9.5t-16.5 -22.5z" />
-          </svg>
-          Gurobi
-        </span>
-        ${thisVersionName}
-        <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24">
-          <path fill="var(--color-foreground-primary)" d="M12 5.83L15.17 9 16.59 7.59 12 3 7.41 7.59 8.83 9 12 5.83zM12 18.17L8.83 15 7.41 16.41 12 21l4.59-4.59L15.17 15 12 18.17z"/>
-        </svg>
-      </span>
-      <div class="rst-other-versions">
-        <div class="injected">
-          ${renderVersions(versionsArray, thisVersionSlug)}
-          ${renderDownloads(config)}
-          <dl>
-            <dt>On Read the Docs</dt>
-            <dd>
-              <a href="${config.projects.current.urls.home}">Project Home</a>
-            </dd>
-            <dd>
-              <a href="${config.projects.current.urls.builds}">Builds</a>
-            </dd>
-          </dl>
-          <hr />
-          <small>
-            <span>Hosted by <a href="https://about.readthedocs.com">Read the Docs</a></span>
-          </small>
-        </div>
-      </div>
+  <div class="injected">
+    ${renderVersions(versionsArray, thisVersionSlug)}
+    ${renderDownloads(config)}
+    <dl>
+      <dt>On Read the Docs</dt>
+      <dd>
+        <a href="${config.projects.current.urls.home}">Project Home</a>
+      </dd>
+      <dd>
+        <a href="${config.projects.current.urls.builds}">Builds</a>
+      </dd>
+    </dl>
+    <hr />
+    <small>
+      <span>Hosted by <a href="https://about.readthedocs.com">Read the Docs</a></span>
+    </small>
+  </div>
   `;
 
-  // Inject the generated flyout into the body HTML element.
+  const thisVersionLabel = `
+    ${thisVersionName}
+    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24">
+      <path fill="var(--color-foreground-primary)" d="M12 5.83L15.17 9 16.59 7.59 12 3 7.41 7.59 8.83 9 12 5.83zM12 18.17L8.83 15 7.41 16.41 12 21l4.59-4.59L15.17 15 12 18.17z"/>
+    </svg>
+  `;
+
+  // Inject the generated content into the placeholders created in versionflyout.html
   document.getElementById("custom-rtd-flyout-content").innerHTML = flyout;
+  document.getElementById("rtd-version-label").innerHTML = thisVersionLabel;
 
   document.querySelector(".rst-current-version").addEventListener("click", function() {
     this.classList.toggle("active");

--- a/docs_gurobi_com/theme/theme.conf
+++ b/docs_gurobi_com/theme/theme.conf
@@ -1,6 +1,6 @@
 [theme]
 inherit = gurobi_sphinxtheme
-stylesheet = styles/furo.css,gurobi.css,docs_gurobi_com.css
+stylesheet = styles/furo.css,gurobi.css,docs_gurobi_com.css,versionflyout.css
 sidebars =
   sidebar/brand.html,
   sidebar/search.html,

--- a/docs_gurobi_com/theme/versionflyout.html
+++ b/docs_gurobi_com/theme/versionflyout.html
@@ -1,16 +1,16 @@
 <div id="custom-rtd-flyout-container">
-  <div class="rst-versions" data-toggle="rst-versions" role="note">
-    <span class="rst-current-version" data-toggle="rst-current-version">
+  <div class="grb-rtd-versions" data-toggle="grb-rtd-versions" role="note">
+    <span class="grb-rtd-current-version" data-toggle="grb-rtd-current-version">
       <span class="fa fa-book">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -100 1664 1664" width="13" height="13" style="transform: scaleY(-1) translateY(-1px);">
           <path fill="var(--color-foreground-primary)" d="M1639 1058q40 -57 18 -129l-275 -906q-19 -64 -76.5 -107.5t-122.5 -43.5h-923q-77 0 -148.5 53.5t-99.5 131.5q-24 67 -2 127q0 4 3 27t4 37q1 8 -3 21.5t-3 19.5q2 11 8 21t16.5 23.5t16.5 23.5q23 38 45 91.5t30 91.5q3 10 0.5 30t-0.5 28q3 11 17 28t17 23q21 36 42 92t25 90q1 9 -2.5 32t0.5 28q4 13 22 30.5t22 22.5q19 26 42.5 84.5t27.5 96.5q1 8 -3 25.5t-2 26.5q2 8 9 18t18 23t17 21q8 12 16.5 30.5t15 35t16 36t19.5 32t26.5 23.5t36 11.5t47.5 -5.5l-1 -3q38 9 51 9h761q74 0 114 -56t18 -130l-274 -906q-36 -119 -71.5 -153.5t-128.5 -34.5h-869q-27 0 -38 -15q-11 -16 -1 -43q24 -70 144 -70h923q29 0 56 15.5t35 41.5l300 987q7 22 5 57q38 -15 59 -43zM575 1056q-4 -13 2 -22.5t20 -9.5h608q13 0 25.5 9.5t16.5 22.5l21 64q4 13 -2 22.5t-20 9.5h-608q-13 0 -25.5 -9.5t-16.5 -22.5zM492 800q-4 -13 2 -22.5t20 -9.5h608q13 0 25.5 9.5t16.5 22.5l21 64q4 13 -2 22.5t-20 9.5h-608q-13 0 -25.5 -9.5t-16.5 -22.5z" />
         </svg>
         Gurobi
       </span>
-      <span id="rtd-version-label">
+      <span id="grb-rtd-version-label">
       </span>
     </span>
-    <div class="rst-other-versions" id="custom-rtd-flyout-content">
+    <div class="grb-rtd-other-versions" id="grb-rtd-flyout-content">
     </div>
   </div>
 </div>

--- a/docs_gurobi_com/theme/versionflyout.html
+++ b/docs_gurobi_com/theme/versionflyout.html
@@ -1,4 +1,16 @@
 <div id="custom-rtd-flyout-container">
-<div id="custom-rtd-flyout-content">
-</div>
+  <div class="rst-versions" data-toggle="rst-versions" role="note">
+    <span class="rst-current-version" data-toggle="rst-current-version">
+      <span class="fa fa-book">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -100 1664 1664" width="13" height="13" style="transform: scaleY(-1) translateY(-1px);">
+          <path fill="var(--color-foreground-primary)" d="M1639 1058q40 -57 18 -129l-275 -906q-19 -64 -76.5 -107.5t-122.5 -43.5h-923q-77 0 -148.5 53.5t-99.5 131.5q-24 67 -2 127q0 4 3 27t4 37q1 8 -3 21.5t-3 19.5q2 11 8 21t16.5 23.5t16.5 23.5q23 38 45 91.5t30 91.5q3 10 0.5 30t-0.5 28q3 11 17 28t17 23q21 36 42 92t25 90q1 9 -2.5 32t0.5 28q4 13 22 30.5t22 22.5q19 26 42.5 84.5t27.5 96.5q1 8 -3 25.5t-2 26.5q2 8 9 18t18 23t17 21q8 12 16.5 30.5t15 35t16 36t19.5 32t26.5 23.5t36 11.5t47.5 -5.5l-1 -3q38 9 51 9h761q74 0 114 -56t18 -130l-274 -906q-36 -119 -71.5 -153.5t-128.5 -34.5h-869q-27 0 -38 -15q-11 -16 -1 -43q24 -70 144 -70h923q29 0 56 15.5t35 41.5l300 987q7 22 5 57q38 -15 59 -43zM575 1056q-4 -13 2 -22.5t20 -9.5h608q13 0 25.5 9.5t16.5 22.5l21 64q4 13 -2 22.5t-20 9.5h-608q-13 0 -25.5 -9.5t-16.5 -22.5zM492 800q-4 -13 2 -22.5t20 -9.5h608q13 0 25.5 9.5t16.5 22.5l21 64q4 13 -2 22.5t-20 9.5h-608q-13 0 -25.5 -9.5t-16.5 -22.5z" />
+        </svg>
+        Gurobi
+      </span>
+      <span id="rtd-version-label">
+      </span>
+    </span>
+    <div class="rst-other-versions" id="custom-rtd-flyout-content">
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
Just to avoid dynamic layout shifting. This becomes important when trying to automatically scroll the right part of the contents sidebar into view.