### PR TITLE
adapt display settings for headings

### DIFF
--- a/gurobi_sphinxtheme/theme/static/gurobi.css
+++ b/gurobi_sphinxtheme/theme/static/gurobi.css
@@ -4,22 +4,39 @@ body {
 
 h1 {
   font-size: 2em; /* 32px */
+  font-weight: bold;
+  color: #000000;
+  margin-top: 1.5em;
 }
 
 h2 {
   font-size: 1.5em; /* 24px */
+  font-weight: bold;
+  color: #222222;
+  margin-top: 1.3em;
+
 }
 
 h3 {
   font-size: 1.25em; /* 20px */
+  font-weight: bold;
+  color: #333333;
+  margin-top: 1.1em;
 }
 
 h4 {
   font-size: 1.17em; /* 18.72px */
+  font-weight: 600;
+  color: #333333;
+  margin-top: 1.0em;
+  font-style: italic;
 }
 
 h5 {
   font-size: 1em; /* 16px */
+  font-weight: 600;
+  color: #444444;
+  margin-top: 1.0em;
 }
 
 h2::before {


### PR DESCRIPTION
This is a proposal to have a better distinction between the different headings, see https://github.com/Gurobi/docs-optimizer/issues/608
With the change the headings h1 to h5 should be displayed as in this example

![image](https://github.com/user-attachments/assets/500820b2-005c-4fd0-a0d1-e121c606e368)
